### PR TITLE
Add release/patch steps for cloudfront cache invalidation

### DIFF
--- a/.github/ISSUE_TEMPLATE/patch_release.md
+++ b/.github/ISSUE_TEMPLATE/patch_release.md
@@ -26,6 +26,7 @@ examples of each step, assuming vX.Y.Z is being cut.
 - [ ] Confirm the full set of patch versions that will be released and promote them from lowest to highest, so the **highest** version is the **last** to be promoted (e.g. `v1.12.2` should be promoted after `v1.11.3`), in order to avoid the promote workflow overwriting the latest patch release.
 - [ ] Run the [Promote workflow][promote-workflow] with channel `stable` on the `release-X.Y` branch and verified that the tagged build version exists on the [releases.crossplane.io] `stable` channel at `stable/vX.Y.Z/...`.
 - [ ] Published a [new release] for the tagged version, with the same name as the version and descriptive release notes, taking care of generating the changes list selecting as "Previous tag" `vX.Y.<Z-1>`, so the previous patch release for the same minor. Before publishing the release notes, set them as Draft and ask the rest of the team to double check them.
+- [ ] Request @jbw976 to perform a CloudFront cache invalidation on https://charts.upbound.io/stable/ and https://releases.crossplane.io/stable/ 
 - [ ] Ensured that users have been notified of the release on all communication channels:
   - [ ] Slack: `#announcements` channel on Crossplane's Slack workspace.
   - [ ] Twitter: reach out to a Crossplane maintainer or steering committee member, see [OWNERS.md][owners].

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -62,6 +62,7 @@ examples of each step, assuming release vX.Y.0 is being cut.
   - [ ] The [releases table] in the `README.md`, removing the now old unsupported release and adding the new one.
   - [ ] The `baseBranches` list in `.github/renovate.json5`, removing the now old unsupported release and adding the new one.
 - [ ] Closed the GitHub milestone for this release.
+- [ ] Request @jbw976 to perform a CloudFront cache invalidation on https://charts.upbound.io/stable/ and https://releases.crossplane.io/stable/ 
 - [ ] Publish a blog post about the release to the [crossplane blog]
   - https://blog.crossplane.io/crossplane-v1-14/
 - [ ] Ensured that users have been notified of the release on all communication channels:


### PR DESCRIPTION
This PR adds a new step to the release and patch release process to perform a cache invalidation in CloudFront for both releases.crossplane.io and charts.crossplane.io.  Too many times we have had folks in various global regions report that they are still seeing the previous version after a release, both for the helm chart and for the CI binary.

The solution has always been to perform an invalidation in CloudFront, so this PR codifies that into a formal step of the process.

Fixes https://github.com/crossplane/crossplane/issues/5571 