### PR TITLE
chore: add Crossplane Runtime steps to patch release template

### DIFF
--- a/.github/ISSUE_TEMPLATE/patch_release.md
+++ b/.github/ISSUE_TEMPLATE/patch_release.md
@@ -21,7 +21,12 @@ Please ensure all artifacts (PRs, workflow runs, Tweets, etc) are linked from
 this issue for posterity. Refer to this [prior release issue][release-1.11.1] for
 examples of each step, assuming vX.Y.Z is being cut.
 
-- [ ] Run the [Tag workflow][tag-workflow] on the `release-X.Y`branch with the proper release version, `vX.Y.Z`. Message suggested, but not required: `Release vX.Y.Z`.
+- [ ] Determine whether a Crossplane Runtime patch is needed by checking if the `release-X.Y` branch of `crossplane-runtime` has commits ahead of its latest tag. If so, cut a Crossplane Runtime patch and consume it from Crossplane:
+  - [ ] **[In Crossplane Runtime]**:
+    - [ ] Run the [Tag workflow][tag-workflow-runtime] on the `release-X.Y` branch with the proper release version, `vX.Y.<R>`. Message suggested, but not required: `Release vX.Y.<R>`.
+    - [ ] Published a [new release][new runtime release] for the tagged version, with the same name as the version, taking care of generating the changes list selecting as "Previous tag" `vX.Y.<R-1>`, so the previous patch release for the same minor (or `vX.Y.0` for the first patch).
+  - [ ] **[In Core Crossplane]:** (On the **Release** Branch) Open and merge a PR updating the Crossplane Runtime dependency to `vX.Y.<R>`.
+- [ ] Run the [Tag workflow][tag-workflow] on the `release-X.Y` branch with the proper release version, `vX.Y.Z`. Message suggested, but not required: `Release vX.Y.Z`.
 - [ ] Run the [CI workflow][ci-workflow] on the release branch and verified that the tagged build version exists on the [releases.crossplane.io] `build` channel, e.g. `build/release-X.Y/vX.Y.Z/...` should contain all the relevant binaries.
 - [ ] Confirm the full set of patch versions that will be released and promote them from lowest to highest, so the **highest** version is the **last** to be promoted (e.g. `v1.12.2` should be promoted after `v1.11.3`), in order to avoid the promote workflow overwriting the latest patch release.
   - NOTE: This ordering requirement can be avoided by checking the "pre-release" checkbox in the promote workflow for the older releases, as described in [#5420].
@@ -45,4 +50,6 @@ examples of each step, assuming vX.Y.Z is being cut.
 [releases table]: https://github.com/crossplane/crossplane#releases
 [releases.crossplane.io]: https://releases.crossplane.io
 [tag-workflow]: https://github.com/crossplane/crossplane/actions/workflows/tag.yml
+[tag-workflow-runtime]: https://github.com/crossplane/crossplane-runtime/actions/workflows/tag.yml
+[new runtime release]: https://github.com/crossplane/crossplane-runtime/releases/new
 [#5420]: https://github.com/crossplane/crossplane/issues/5420#issuecomment-2318294855

--- a/.github/ISSUE_TEMPLATE/patch_release.md
+++ b/.github/ISSUE_TEMPLATE/patch_release.md
@@ -23,9 +23,9 @@ examples of each step, assuming vX.Y.Z is being cut.
 
 - [ ] Determine whether a Crossplane Runtime patch is needed by checking if the `release-X.Y` branch of `crossplane-runtime` has commits ahead of its latest tag. If so, cut a Crossplane Runtime patch and consume it from Crossplane:
   - [ ] **[In Crossplane Runtime]**:
-    - [ ] Run the [Tag workflow][tag-workflow-runtime] on the `release-X.Y` branch with the proper release version, `vX.Y.<R>`. Message suggested, but not required: `Release vX.Y.<R>`.
-    - [ ] Published a [new release][new runtime release] for the tagged version, with the same name as the version, taking care of generating the changes list selecting as "Previous tag" `vX.Y.<R-1>`, so the previous patch release for the same minor (or `vX.Y.0` for the first patch).
-  - [ ] **[In Core Crossplane]:** (On the **Release** Branch) Open and merge a PR updating the Crossplane Runtime dependency to `vX.Y.<R>`.
+    - [ ] Run the [Tag workflow][tag-workflow-runtime] on the `release-X.Y` branch with the proper release version, `vX.Y.Z`. Message suggested, but not required: `Release vX.Y.Z`.
+    - [ ] Published a [new release][new runtime release] for the tagged version, with the same name as the version, taking care of generating the changes list selecting as "Previous tag" `vX.Y.<Z-1>`, so the previous patch release for the same minor (or `vX.Y.0` for the first patch).
+  - [ ] **[In Core Crossplane]:** (On the **Release** Branch) Open and merge a PR updating the Crossplane Runtime dependency to `vX.Y.Z`.
 - [ ] Run the [Tag workflow][tag-workflow] on the `release-X.Y` branch with the proper release version, `vX.Y.Z`. Message suggested, but not required: `Release vX.Y.Z`.
 - [ ] Run the [CI workflow][ci-workflow] on the release branch and verified that the tagged build version exists on the [releases.crossplane.io] `build` channel, e.g. `build/release-X.Y/vX.Y.Z/...` should contain all the relevant binaries.
 - [ ] Confirm the full set of patch versions that will be released and promote them from lowest to highest, so the **highest** version is the **last** to be promoted (e.g. `v1.12.2` should be promoted after `v1.11.3`), in order to avoid the promote workflow overwriting the latest patch release.


### PR DESCRIPTION
## Summary

- Add runtime-patch steps to `patch_release.md`, mirroring the minor release template.
- Patch releases regularly need a corresponding crossplane-runtime patch (e.g. CVE/Go bumps landed on runtime's release branch since the last tag). Without steps in the template they're easy to miss — the 4 patch issues just filed (#64–#67) all had to have runtime steps added after the fact.
- Incidentally fixes a missing space on the existing tag-workflow line (`` `release-X.Y`branch `` → `` `release-X.Y` branch ``).

## Test plan
- [ ] Open a new issue from the `Patch Release` template and confirm checkboxes and link references render correctly.
- [ ] Cross-check the two new link refs (`[tag-workflow-runtime]`, `[new runtime release]`) resolve.