### PR TITLE
docs: refine release issue templates from v2.3 release feedback

### DIFF
--- a/.github/ISSUE_TEMPLATE/patch_release.md
+++ b/.github/ISSUE_TEMPLATE/patch_release.md
@@ -21,13 +21,15 @@ Please ensure all artifacts (PRs, workflow runs, Tweets, etc) are linked from
 this issue for posterity. Refer to this [prior release issue][release-1.11.1] for
 examples of each step, assuming vX.Y.Z is being cut.
 
-- [ ] Determine whether a Crossplane Runtime patch is needed by checking if the `release-X.Y` branch of `crossplane-runtime` has commits ahead of its latest tag. If so, cut a Crossplane Runtime patch and consume it from Crossplane:
-  - [ ] **[In Crossplane Runtime]**:
-    - [ ] Confirm that all security/critical dependency update PRs from Renovate are merged into the `release-X.Y` branch
-      - https://github.com/crossplane/crossplane-runtime/pulls?q=is%3Apr+is%3Aopen+label%3Aautomated
-    - [ ] Run the [Tag workflow][tag-workflow-runtime] on the `release-X.Y` branch with the proper release version, `vX.Y.Z`. Message suggested, but not required: `Release vX.Y.Z`.
-    - [ ] Published a [new release][new runtime release] for the tagged version, with the same name as the version, taking care of generating the changes list selecting as "Previous tag" `vX.Y.<Z-1>`, so the previous patch release for the same minor (or `vX.Y.0` for the first patch).
-  - [ ] **[In Core Crossplane]:** (On the **Release** Branch) Open and merge a PR updating the Crossplane Runtime dependency to `vX.Y.Z`.
+- [ ] Determine whether a Crossplane Runtime patch is needed by checking if the `release-X.Y` branch of `crossplane-runtime` has commits ahead of its latest tag.
+  - One way to check this is `git log $(git describe --tags --abbrev=0 upstream/release-X.Y)..upstream/release-X.Y --oneline`, if it shows any commits then a patch release is needed.
+  - If a Crossplane Runtime patch is needed, cut a Crossplane Runtime patch and consume it from Crossplane:
+    - [ ] **[In Crossplane Runtime]**:
+      - [ ] Confirm that all security/critical dependency update PRs from Renovate are merged into the `release-X.Y` branch
+        - https://github.com/crossplane/crossplane-runtime/pulls?q=is%3Apr+is%3Aopen+label%3Aautomated
+      - [ ] Run the [Tag workflow][tag-workflow-runtime] on the `release-X.Y` branch with the proper release version, `vX.Y.Z`. Message suggested, but not required: `Release vX.Y.Z`.
+      - [ ] Published a [new release][new runtime release] for the tagged version, with the same name as the version, taking care of generating the changes list selecting as "Previous tag" `vX.Y.<Z-1>`, so the previous patch release for the same minor (or `vX.Y.0` for the first patch).
+    - [ ] **[In Core Crossplane]:** (On the **Release** Branch) Open and merge a PR updating the Crossplane Runtime dependency to `vX.Y.Z`.
 - [ ] Confirm that all security/critical dependency update PRs from Renovate are merged into the `release-X.Y` branch
   - https://github.com/crossplane/crossplane/pulls?q=is%3Apr+is%3Aopen+label%3Aautomated
 - [ ] Run the [Tag workflow][tag-workflow] on the `release-X.Y` branch with the proper release version, `vX.Y.Z`. Message suggested, but not required: `Release vX.Y.Z`.

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -58,10 +58,14 @@ examples of each step, assuming release vX.Y.0 is being cut.
 - [ ] Checked that the [GitHub milestone] for this release only contains closed issues.
 - [ ] Cut a Crossplane Runtime version and consume it from Crossplane.
   - [ ] **[In Crossplane Runtime]**:
+    - [ ] Confirm that all security/critical dependency update PRs from Renovate are merged into `release-X.Y`:
+      - https://github.com/crossplane/crossplane-runtime/pulls?q=is%3Apr+is%3Aopen+label%3Aautomated
     - [ ] Run the [Tag workflow][tag-workflow-runtime] on the `release-X.Y` branch with the proper release version, `vX.Y.0`. Message suggested, but not required: `Release vX.Y.0`.
     - [ ] Published a [new release][new runtime release] for the tagged version, with the same name as the version, taking care of generating the changes list selecting as "Previous tag" `vX.<Y-1>.0`, so the first of the releases for the previous minor.
     - [ ] Update the `baseBranches` list in `.github/renovate-base.json5` on `main`, removing the now old unsupported release.
   - [ ] **[In Core Crossplane]:** (On the **Release** Branch) Update the Crossplane Runtime dependency to `vX.Y.0`.
+- [ ] (On the **Release** Branch) Confirm that all security/critical dependency update PRs from Renovate are merged into `release-X.Y`:
+    - https://github.com/crossplane/crossplane/pulls?q=is%3Apr+is%3Aopen+label%3Aautomated
 - [ ] (On the **Release** Branch) Run the [Tag workflow][tag-workflow] with the proper release version, `vX.Y.0`. Message suggested, but not required: `Release vX.Y.0`.
 - [ ] (On the **Release** Branch) Run the [CI workflow][ci-workflow] and verified that the tagged build version exists on the [releases.crossplane.io] `build` channel, e.g. `build/release-X.Y/vX.Y.0/...` should contain all the relevant binaries.
 - [ ] (On the **Release** Branch) Run the [Promote workflow][promote-workflow] with channel `stable` and verified that the tagged build version exists on the [releases.crossplane.io] `stable` channel at `stable/vX.Y.0/...`.


### PR DESCRIPTION
This PR contains improvements from the the v2.3 release process.

In the patch release template, add a concrete `git log` command to help folks determine whether the `release-X.Y` branch of crossplane-runtime has commits ahead of its latest tag.

In the release template, add steps to confirm that all security/critical dependency update PRs from Renovate are merged in both crossplane-runtime and core Crossplane on release day, similar to what we do for code freeze RC. These days, there are often new security fixes that pop up in between RC and official release, so ABC - always be checking 😂 